### PR TITLE
Correction/inference creation forbidden validation

### DIFF
--- a/src/adapters/routers/v1/inference_router.py
+++ b/src/adapters/routers/v1/inference_router.py
@@ -8,7 +8,7 @@ from core.ports.authentication_port import AuthenticationPort
 from core.ports.database_port import DatabasePort
 
 from core.model.user import User
-from core.model.inference import Inference, InferenceCreation
+from core.model.inference import Inference, InferenceCreationForm
 from core.model.exception import LogicException
 from core.services.inference_service import create_new_inference, get_by_id, get_list
 
@@ -53,7 +53,7 @@ def create_inference_router(
     @router.post("/{user_id}/inferences")
     def create_inference(
         user_id: str,
-        inference_form: InferenceCreation,
+        inference_form: InferenceCreationForm,
         token_content: str = Depends(oauth2_scheme),
     ):
         try:

--- a/src/core/model/inference.py
+++ b/src/core/model/inference.py
@@ -14,3 +14,9 @@ class InferenceCreation(BaseModel):
     sex: str
     user_id: str
     model_id: str
+
+
+class InferenceCreationForm(BaseModel):
+    age: int
+    sex: str
+    model_id: str

--- a/src/core/services/inference_service.py
+++ b/src/core/services/inference_service.py
@@ -4,7 +4,7 @@ from core.model.token import Token
 from core.ports.authentication_port import AuthenticationPort
 
 from core.ports.database_port import DatabasePort
-from core.model.inference import Inference, InferenceCreationForm
+from core.model.inference import Inference, InferenceCreation, InferenceCreationForm
 from core.model.exception import DefaultExceptions, LogicException
 
 import core.services.model_service as model_service
@@ -102,7 +102,13 @@ def create_new_inference(
         raise e
 
     try:
-        database_port.insert_inference(inference_form)
+        new_inference = InferenceCreation(
+            age=inference_form.age,
+            sex=inference_form.sex,
+            user_id=user_id,
+            model_id=inference_form.model_id,
+        )
+        database_port.insert_inference(new_inference)
     except:
         raise LogicException(
             "cound not create new inference", status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/tests/unit_tests/test_inference.py
+++ b/tests/unit_tests/test_inference.py
@@ -94,7 +94,6 @@ def test_post_create_inference_success(client_with_auth: TestClient):
         "sex": "F",
         "age": 23,
         "model_id": "629f992d45cda830033cf4cd",
-        "user_id": "507f191e810c19729de860ea",
     }
     response = client_with_auth.post(
         "/v1/users/507f191e810c19729de860ea/inferences",


### PR DESCRIPTION
-Purpose:

User id was set to be specified in request body when creating an inference.
Inconsistencies were found when validating if the operation was allowed for the requesting user (user specifying a different user_id in request body than the one in url and in the token)
User id does not need to be in request body anymore, since user can already be identified through token validation.