### PR TITLE
Test calls reorganization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,4 +41,4 @@ jobs:
           poetry install --no-interaction --no-ansi
 
       - name: Run tests
-        run: python3 -m pytest --import-mode=append tests/
+        run: make -f tests.mk

--- a/tests.mk
+++ b/tests.mk
@@ -1,0 +1,9 @@
+make:
+	@echo running unit tests for adapters
+	python3 -m py.test tests/unit_tests/adapters
+
+	@echo running unit tests for ports
+	python3 -m py.test tests/unit_tests/ports
+
+	@echo running integration tests for endpoints
+	python3 -m py.test tests/integration_tests


### PR DESCRIPTION
-Purpose:

With the last pr including unit tests, it was necessary to separate test calls by hierarchy and centralize them in on command.