### PR TITLE
Refactor/uploadfile type dependency

### DIFF
--- a/src/adapters/routers/v1/inference_router.py
+++ b/src/adapters/routers/v1/inference_router.py
@@ -2,12 +2,7 @@ from typing import List, Optional
 from fastapi import (
     APIRouter,
     Depends,
-    File,
     HTTPException,
-    File,
-    Form,
-    UploadFile,
-    status,
 )
 from fastapi.encoders import jsonable_encoder
 from fastapi.security import OAuth2PasswordBearer

--- a/src/adapters/routers/v1/utils/form_helpers.py
+++ b/src/adapters/routers/v1/utils/form_helpers.py
@@ -1,5 +1,5 @@
 from fastapi import File, Form, UploadFile
-from core.model.inference import InferenceCreationForm, InferenceFiles
+from core.model.inference import InferenceCreationForm, InferenceFiles, UploadAudio
 
 
 async def get_inference_form_model(age=Form(-1), sex=Form(""), model_id=Form("")):
@@ -12,7 +12,11 @@ async def get_inference_form_files(
     frase: UploadFile = File(None),
 ):
     return InferenceFiles(
-        vogal_sustentada=vogal_sustentada,
-        parlenda_ritmada=parlenda_ritmada,
-        frase=frase,
+        vogal_sustentada=UploadAudio(
+            content=vogal_sustentada.file.read(), filename=vogal_sustentada.filename
+        ),
+        parlenda_ritmada=UploadAudio(
+            content=parlenda_ritmada.file.read(), filename=parlenda_ritmada.filename
+        ),
+        frase=UploadAudio(content=frase.file.read(), filename=frase.filename),
     )

--- a/src/adapters/simple_storage/minio_adapter.py
+++ b/src/adapters/simple_storage/minio_adapter.py
@@ -1,6 +1,5 @@
 from io import BytesIO
 import os
-from fastapi import UploadFile
 from minio import Minio
 from minio.deleteobjects import DeleteObject
 

--- a/src/adapters/simple_storage/minio_adapter.py
+++ b/src/adapters/simple_storage/minio_adapter.py
@@ -1,5 +1,5 @@
+from io import BytesIO
 import os
-import io
 from fastapi import UploadFile
 from minio import Minio
 from minio.deleteobjects import DeleteObject
@@ -14,10 +14,11 @@ class MinioAdapter:
         if not self._client.bucket_exists(bucket_name):
             self._client.make_bucket(bucket_name)
 
-    def store_inference_file(self, inference_id: str, file_type: str, file: UploadFile):
-        raw_file = io.BytesIO(file.file.read())
+    def store_inference_file(
+        self, inference_id: str, file_type: str, file_extension: str, raw_file: BytesIO
+    ):
+
         length = raw_file.getbuffer().nbytes
-        _, file_extension = os.path.splitext(file.filename)
         self._client.put_object(
             self._bucket_name,
             inference_id + os.sep + file_type + file_extension,

--- a/src/core/model/inference.py
+++ b/src/core/model/inference.py
@@ -1,4 +1,3 @@
-from typing import Any
 from pydantic import BaseModel
 
 
@@ -22,7 +21,12 @@ class InferenceCreation(InferenceCreationForm):
     user_id: str
 
 
+class UploadAudio(BaseModel):
+    content: bytes
+    filename: str
+
+
 class InferenceFiles(BaseModel):
-    vogal_sustentada: Any
-    parlenda_ritmada: Any
-    frase: Any
+    vogal_sustentada: UploadAudio
+    parlenda_ritmada: UploadAudio
+    frase: UploadAudio

--- a/src/core/ports/simple_storage_port.py
+++ b/src/core/ports/simple_storage_port.py
@@ -1,4 +1,7 @@
-from fastapi import UploadFile
+from io import BytesIO
+import os
+
+from core.model.inference import UploadAudio
 
 
 class SimpleStoragePort:
@@ -6,10 +9,11 @@ class SimpleStoragePort:
         self._simples_storage_adapter = simple_storage_adapter
 
     def store_inference_file(
-        self, inference_id: str, file_type: str, file: UploadFile
+        self, inference_id: str, file_type: str, audio_file: UploadAudio
     ) -> None:
+        _, file_extension = os.path.splitext(audio_file.filename)
         self._simples_storage_adapter.store_inference_file(
-            inference_id, file_type, file
+            inference_id, file_type, file_extension, BytesIO(audio_file.content)
         )
 
     def remove_inference_directory(self, inference_id: str) -> None:

--- a/tests/unit_tests/adapters/simple_storage/test_simple_storage_adapter.py
+++ b/tests/unit_tests/adapters/simple_storage/test_simple_storage_adapter.py
@@ -24,11 +24,12 @@ def test_store_inference_file(simple_storage_adapter: MinioAdapter):
         "put_object",
         MagicMock(side_effect=fake_put_object),
     ) as mock_method:
-        file = UploadFile("tests/mocks/audio_files/audio1.wav")
+        file = BytesIO(UploadFile("tests/mocks/audio_files/audio1.wav").file.read())
         try:
             simple_storage_adapter.store_inference_file(
                 "fake_inference_id",
                 "fake_file_type",
+                ".fake_extension",
                 file,
             )
             assert True
@@ -36,7 +37,7 @@ def test_store_inference_file(simple_storage_adapter: MinioAdapter):
             assert False
         mock_method.assert_called_once_with(
             "mock-bucket",
-            "fake_inference_id/fake_file_type.wav",
+            "fake_inference_id/fake_file_type.fake_extension",
             ANY,
             0,
         )

--- a/tests/unit_tests/ports/test_simple_storage_port.py
+++ b/tests/unit_tests/ports/test_simple_storage_port.py
@@ -1,6 +1,8 @@
+from io import BytesIO
 from fastapi import UploadFile
-from mock import MagicMock, patch
+from mock import ANY, MagicMock, patch
 import pytest
+from core.model.inference import UploadAudio
 from core.ports.simple_storage_port import SimpleStoragePort
 
 from tests.mocks.minio_mock import MinioMock
@@ -15,10 +17,15 @@ def simple_storage_port():
 
 
 def test_store_inference_file(simple_storage_port: SimpleStoragePort):
-    def store_inference_file(inference_id, file_type, file) -> None:
+    def store_inference_file(
+        inference_id: str, file_type: str, extension: str, file: BytesIO
+    ) -> None:
         pass
 
-    file = UploadFile("tests/mocks/audio_files/audio1.wav")
+    file = UploadAudio(
+        content=UploadFile("tests/mocks/audio_files/audio1.wav").file.read(),
+        filename="tests/mocks/audio_files/audio1.wav",
+    )
 
     with patch.object(
         adapter_instance,
@@ -34,7 +41,8 @@ def test_store_inference_file(simple_storage_port: SimpleStoragePort):
         mock_store_inference_file.assert_called_once_with(
             "507f191e810c19729de860ea",
             "fake_file_type",
-            file,
+            ".wav",
+            ANY,
         )
 
 

--- a/tests/unit_tests/services/test_inference_service.py
+++ b/tests/unit_tests/services/test_inference_service.py
@@ -2,7 +2,7 @@ from fastapi import UploadFile
 from h11 import Data
 from mock import MagicMock, patch, call
 import pytest
-from core.model.inference import InferenceFiles
+from core.model.inference import InferenceFiles, UploadAudio
 from core.ports.simple_storage_port import SimpleStoragePort
 from core.services.inference_service import _store_files
 from tests.mocks.minio_mock import MinioMock
@@ -23,10 +23,18 @@ def test_store_files_success(simple_storage_port: SimpleStoragePort):
         "store_inference_file",
         MagicMock(side_effect=fake_store_inference_file),
     ) as mock_store_inference_file:
+
+        vogal_sustentada = UploadFile("tests/mocks/audio_files/audio1.wav")
+        parlenda_ritmada = UploadFile("tests/mocks/audio_files/audio2.wav")
+        frase = UploadFile("tests/mocks/audio_files/audio3.wav")
         inference_files = InferenceFiles(
-            vogal_sustentada=UploadFile("tests/mocks/audio_files/audio1.wav"),
-            parlenda_ritmada=UploadFile("tests/mocks/audio_files/audio2.wav"),
-            frase=UploadFile("tests/mocks/audio_files/audio3.wav"),
+            vogal_sustentada=UploadAudio(
+                content=vogal_sustentada.file.read(), filename=vogal_sustentada.filename
+            ),
+            parlenda_ritmada=UploadAudio(
+                content=parlenda_ritmada.file.read(), filename=parlenda_ritmada.filename
+            ),
+            frase=UploadAudio(content=frase.file.read(), filename=frase.filename),
         )
         _store_files(simple_storage_port, inference_files, "fake_inference_id")
         calls = [


### PR DESCRIPTION
-Purpose:

UploadFile is a fastapi class. Thus, it cannot be used as a dependency for the core code. A new abstraction for UploadFiles was created and implemented.